### PR TITLE
Improve invalid security type holdings handling

### DIFF
--- a/QuantConnect.TDAmeritrade/Utils/Extensions.cs
+++ b/QuantConnect.TDAmeritrade/Utils/Extensions.cs
@@ -305,7 +305,8 @@ namespace QuantConnect.Brokerages.TDAmeritrade.Utils
         public static SecurityType ConvertBrokerageSecurityTypeToLeanSecurityType(this string brokerageSecurityType) => brokerageSecurityType switch
         {
             "EQUITY" => SecurityType.Equity,
-            _ => throw new ArgumentException($"TDAmeritrade doesn't support of SecurityType {nameof(brokerageSecurityType)}")
+            _ => throw new ArgumentException($"TDAmeritrade doesn't support brokerage security type {brokerageSecurityType}. " +
+                $"Only {SecurityType.Equity} is currently supported.")
         };
     }
 }


### PR DESCRIPTION
- Improve invalid security type holdings handling
In master
```
ERROR:: BrokerageSetupHandler.LoadExistingHoldingsAndOrders():  System.ArgumentException: TDAmeritrade doesn't support of SecurityType brokerageSecurityType
```