### PR TITLE
Return null on unsupported history and data download requests

### DIFF
--- a/QuantConnect.TDAmeritrade/TDAmeritradeBrokerage.HistoryProvider.cs
+++ b/QuantConnect.TDAmeritrade/TDAmeritradeBrokerage.HistoryProvider.cs
@@ -25,27 +25,49 @@ namespace QuantConnect.Brokerages.TDAmeritrade
     public partial class TDAmeritradeBrokerage
     {
         private bool _loggedTDASupportsOnlyTradeBars;
+        private bool _loggedTDAUnsupportedSecurityTypeForHistory;
+        private bool _loggedInvalidTimeRangeForHistory;
+        private bool _loggedInvalidCanonicalSymbolForHistory;
+        private bool _loggedTDAUnsupportedResolutionForHistory;
 
         /// <summary>
         /// Gets the history for the requested security
         /// </summary>
         /// <param name="request">The historical data request</param>
         /// <returns>An enumerable of bars covering the span specified in the request</returns>
-        public override IEnumerable<BaseData> GetHistory(HistoryRequest request)
+        public override IEnumerable<BaseData>? GetHistory(HistoryRequest request)
         {
             if (request.Symbol.ID.SecurityType != SecurityType.Equity)
             {
-                throw new ArgumentException($"Invalid security type: {request.Symbol.ID.SecurityType}");
+                if (!_loggedTDAUnsupportedSecurityTypeForHistory)
+                {
+                    _loggedTDAUnsupportedSecurityTypeForHistory = true;
+                    _algorithm?.Debug("Warning: TDAmeritrade history provider only supports equities.");
+                    Log.Error("TDAmeritradeBrokerage.GetHistory(): TDAmeritrade only supports equities");
+                }
+                return null;
             }
 
             if (request.StartTimeUtc >= request.EndTimeUtc)
             {
-                throw new ArgumentException("Invalid date range specified start time can not be after end time");
+                if (!_loggedInvalidTimeRangeForHistory)
+                {
+                    _loggedInvalidTimeRangeForHistory = true;
+                    _algorithm?.Debug("Warning: TDAmeritrade history provider received an invalid date range for history request.");
+                    Log.Error("TDAmeritradeBrokerage.GetHistory(): Invalid date range specified");
+                }
+                return null;
             }
 
             if (request.Symbol.IsCanonical())
             {
-                throw new ArgumentException("Invalid symbol, cannot use canonical symbols for history request");
+                if (!_loggedInvalidCanonicalSymbolForHistory)
+                {
+                    _loggedInvalidCanonicalSymbolForHistory = true;
+                    _algorithm?.Debug("Warning: TDAmeritrade history provider received an invalid symbol for history request.");
+                    Log.Error("TDAmeritradeBrokerage.GetHistory(): Invalid symbol, cannot use canonical symbols for history request");
+                }
+                return null;
             }
 
             if (request.TickType != TickType.Trade)
@@ -56,7 +78,18 @@ namespace QuantConnect.Brokerages.TDAmeritrade
                     _algorithm?.Debug("Warning: TDAmeritrade history provider only supports trade information, does not support quotes.");
                     Log.Error("TDAmeritradeBrokerage.GetHistory(): TDAmeritrade only supports TradeBars");
                 }
-                yield break;
+                return null;
+            }
+
+            if (request.Resolution < Resolution.Minute)
+            {
+                if (!_loggedTDAUnsupportedResolutionForHistory)
+                {
+                    _loggedTDAUnsupportedResolutionForHistory = true;
+                    _algorithm?.Debug("Warning: TDAmeritrade history provider only supports minute and higher resolution.");
+                    Log.Error("TDAmeritradeBrokerage.GetHistory(): TDAmeritrade only supports minute and higher resolution");
+                }
+                return null;
             }
 
             var start = request.StartTimeUtc.ConvertTo(DateTimeZone.Utc, TimeZones.NewYork);
@@ -66,10 +99,6 @@ namespace QuantConnect.Brokerages.TDAmeritrade
 
             switch (request.Resolution)
             {
-                case Resolution.Tick:
-                case Resolution.Second:
-                    Log.Error($"TDAmeritrade.GetHistory() doesn't support of resolution {nameof(request.Resolution)}");
-                    break;
                 case Resolution.Minute:
                     history = GetHistory(request, start, end, PeriodType.Day, FrequencyType.Minute);
                     break;
@@ -86,13 +115,9 @@ namespace QuantConnect.Brokerages.TDAmeritrade
                     throw new ArgumentException("Invalid date range specified");
             }
 
-            foreach (var bar in history.Where(bar => bar.Time >= request.StartTimeLocal && bar.EndTime <= request.EndTimeLocal))
-            {
-                if (request.ExchangeHours.IsOpen(bar.Time, bar.EndTime, request.IncludeExtendedMarketHours))
-                {
-                    yield return bar;
-                }
-            }
+            return history.Where(bar => bar.Time >= request.StartTimeLocal &&
+                bar.EndTime <= request.EndTimeLocal &&
+                request.ExchangeHours.IsOpen(bar.Time, bar.EndTime, request.IncludeExtendedMarketHours));
         }
 
         private IEnumerable<BaseData> GetHistory(HistoryRequest request, DateTime start, DateTime end, PeriodType periodType, FrequencyType frequencyType)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Returning null on unsupported history requests instead of returning an empty enumerable. This allows to differentiate empty results from unsupported cases.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
